### PR TITLE
In Vehicle Check

### DIFF
--- a/Enhanced_Crouch/client.lua
+++ b/Enhanced_Crouch/client.lua
@@ -90,7 +90,7 @@ end
 
 RegisterCommand('crouch', function()
 	DisableControlAction(0, 36, true) -- magic
-	if not Cooldown then
+	if not Cooldown and not IsPedInAnyVehicle(PlayerPedId(), false) then
 		CrouchedForce = not CrouchedForce
 
 		if CrouchedForce then


### PR DESCRIPTION
If a player would do a wheelie on a motorbike and he gets off it without the check the script crouches the ped after it gets off the motorbike.